### PR TITLE
Use server hostname for frontend API calls

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -18,8 +18,10 @@
 
 	const userId = inject("userId");
 
-	onMounted(() => {
-		fetch("http://localhost:8000/api/sentiment/start/", {
+        const backendHost = window.location.hostname;
+
+        onMounted(() => {
+                fetch(`http://${backendHost}:8000/api/sentiment/start/`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({

--- a/frontend/src/components/bigdata.vue
+++ b/frontend/src/components/bigdata.vue
@@ -91,8 +91,10 @@
 		chartRef.value?.chart?.update();
 	}
 
-	onMounted(() => {
-		socket = new WebSocket(`ws://localhost:8000/ws/sentiment/${userId}/`);
+        const backendHost = window.location.hostname;
+
+        onMounted(() => {
+                socket = new WebSocket(`ws://${backendHost}:8000/ws/sentiment/${userId}/`);
 		socket.onmessage = (e) => {
 			try {
 				addPointFromServer(JSON.parse(e.data));
@@ -104,12 +106,12 @@
 		chartData.value.labels = [];
 		chartData.value.datasets[0].data = [];
 		chartData.value.datasets[1].data = [];
-		await fetch("http://localhost:8000/api/sentiment/stop/", {
+                await fetch(`http://${backendHost}:8000/api/sentiment/stop/`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ user_id: userId }),
 		}).catch(() => {});
-		await fetch("http://localhost:8000/api/sentiment/start/", {
+                await fetch(`http://${backendHost}:8000/api/sentiment/start/`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({

--- a/web/frontend/src/App.vue
+++ b/web/frontend/src/App.vue
@@ -18,8 +18,10 @@
 
 	const userId = inject("userId");
 
-	onMounted(() => {
-		fetch("http://localhost:8000/api/sentiment/start/", {
+        const backendHost = window.location.hostname;
+
+        onMounted(() => {
+                fetch(`http://${backendHost}:8000/api/sentiment/start/`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({

--- a/web/frontend/src/components/bigdata.vue
+++ b/web/frontend/src/components/bigdata.vue
@@ -90,8 +90,10 @@
 		chartRef.value?.chart?.update();
 	}
 
-	onMounted(() => {
-		socket = new WebSocket(`ws://localhost:8000/ws/sentiment/${userId}/`);
+        const backendHost = window.location.hostname;
+
+        onMounted(() => {
+                socket = new WebSocket(`ws://${backendHost}:8000/ws/sentiment/${userId}/`);
 		socket.onmessage = (e) => {
 			try {
 				addPointFromServer(JSON.parse(e.data));
@@ -103,12 +105,12 @@
 		chartData.value.labels = [];
 		chartData.value.datasets[0].data = [];
 		chartData.value.datasets[1].data = [];
-		await fetch("http://localhost:8000/api/sentiment/stop/", {
+                await fetch(`http://${backendHost}:8000/api/sentiment/stop/`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({ user_id: userId }),
 		}).catch(() => {});
-		await fetch("http://localhost:8000/api/sentiment/start/", {
+                await fetch(`http://${backendHost}:8000/api/sentiment/start/`, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify({


### PR DESCRIPTION
## Summary
- fetch backend hostname from `window.location` so connections work outside localhost

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'config')*
- `docker compose up -d --build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68715e0ede408328ba607478906a6504